### PR TITLE
Use pre for text doc formats

### DIFF
--- a/templates/doc.jade
+++ b/templates/doc.jade
@@ -1,7 +1,10 @@
 - var itemFormat = item.attributes.getValue('format') || 'text'
 
-if itemFormat === 'text' || itemFormat === 'markdown'
+if itemFormat === 'text'
   .doc(data-alps-format='text')
+    pre= item.toValue()
+else if itemFormat === 'markdown'
+  .doc(data-alps-format='markdown')
     :marked
       #{item.toValue()}
 else if itemFormat === 'html'

--- a/test/to-html-test.js
+++ b/test/to-html-test.js
@@ -41,7 +41,7 @@ describe('ALPS namespace', () => {
     // Simple checks to ensure the content is being rendered
     it('should render correctly', () => {
       const alpsHtml = alpsToHtml(alps);
-      expect(alpsHtml).to.include('A contact list.');
+      expect(alpsHtml).to.include('<pre>A contact list.</pre>');
       expect(alpsHtml).to.include('id="collection"');
       expect(alpsHtml).to.include('A simple link/form for getting a list of contacts.');
       expect(alpsHtml).to.include('<dt class="attribute-key">type</dt><dd class="attribute-value">safe</dd>');


### PR DESCRIPTION
Instead of parsing with markdown, just display in `pre` block.
